### PR TITLE
fix: preview token retrieval for craft 4

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -255,7 +255,11 @@ class Plugin extends \craft\base\Plugin
                                 };
                                 
                                 if (doPreview) {
-                                    payload.token = await event.target.draftEditor.getPreviewToken();
+                                    if(event.target.elementEditor) {
+                                        payload.token = await event.target.elementEditor.getPreviewToken();
+                                    } else {
+                                        payload.token = await event.target.draftEditor.getPreviewToken();
+                                    }
                                 } else {
                                     currentlyPreviewing = null;
                                 }


### PR DESCRIPTION
Craft 4 uses "elementEditor" instead of "draftEditor". This allows the script to work with both.